### PR TITLE
Fixed create mandatory params

### DIFF
--- a/src/resources/catalog_category.js
+++ b/src/resources/catalog_category.js
@@ -36,7 +36,7 @@ var protos = {
     Create a new category and return its ID.
   */
   create: {
-    mandatory: 'categoryId,data',
+    mandatory: 'parentId,categoryData',
     optional: 'storeView'
   },
 


### PR DESCRIPTION
Create's mandatory fields now accurately reflects what Magento's API is expecting...otherwise there was a conflict what Magento and the library expected.
