### PR TITLE
Shipment list fix

### DIFF
--- a/readmes/sales_order_shipment.md
+++ b/readmes/sales_order_shipment.md
@@ -70,13 +70,7 @@ magento.salesOrderShipment.list(callback);
 // or 
 
 magento.salesOrderShipment.list({
-  filters: [ val, val, val ]
-}, callback);
-
-// or a single filter
-
-magento.salesOrderShipment.list({
-  filters: val
+  filters: { key: 'val' }
 }, callback);
 ```
 

--- a/src/resources/sales_order_shipment.js
+++ b/src/resources/sales_order_shipment.js
@@ -58,17 +58,7 @@ var protos = {
     Allows you to retrieve the list of order shipments. Additional filters can be applied.
   */
   list: {
-    mandatory: 'filters',
-    modifiers: {
-      filters: function(filters) {
-        // if filters is not an array, wrap it in an array
-        if (!Array.isArray(filters)) {
-          return [ filters ];
-        }
-
-        return filters;
-      }
-    }
+    mandatory: 'filters'
   },
 
   /**


### PR DESCRIPTION
We found that this fixed the filtering capabilities for the salesOrderShipments.list() when using filters.  I created an issue for this before the pull request . . . . I'm new to this.
