### PR TITLE
Allow for https connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "magento",
   "author": "Tim Marshall <timothyjmarshall@gmail.com>",
   "description": "Magento SOAP API wrapper for Node.js",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "./src/magento",
   "contributors": [
     {

--- a/src/magento.js
+++ b/src/magento.js
@@ -42,6 +42,7 @@ var resources = {
   store: './resources/store.js'
 };
 var mandatory = {};
+var isSecure = false;
 var configDefaults = {
   host: mandatory,
   port: 80,
@@ -76,8 +77,25 @@ function Magento(config) {
     }
   }
 
+  // Handle secure authentication
+  // Port 443, or isSecure: true in the
+  // options should make secure requests
+  if (magentoConfig.isSecure !== undefined) {
+    isSecure = magentoConfig.isSecure;
+    delete magentoConfig.isSecure;
+  }
+  if (magentoConfig.port !== undefined) {
+    if (isSecure && magentoConfig.port == 80) {
+      magentoConfig.port == 443;
+    } else if (!isSecure && magentoConfig.port == 443) {
+        isSecure = true;
+    }
+  }
+
   this.config = magentoConfig;
-  this.client = xmlrpc.createClient(this.config);
+  this.client = (isSecure)
+    ? xmlrpc.createSecureClient(this.config)
+    : xmlrpc.createClient(this.config);
   this.queue = [];
   this.queue.running = 0;
   this.queue.parallelLimit = this.config.parallelLimit;


### PR DESCRIPTION
With this change, the client can connect to Magento instances that are behind https. Also incremented the version number. 

If accepted, please remember to npm publish. Version 0.0.4 is the latest still on npm.
