### PR TITLE
Pass basic_auth option to xmlrpc

### DIFF
--- a/src/magento.js
+++ b/src/magento.js
@@ -48,7 +48,8 @@ var configDefaults = {
   path: mandatory,
   login: mandatory,
   pass: mandatory,
-  parallelLimit: Infinity
+  parallelLimit: Infinity,
+  basic_auth: false  // passed to xmlrpc
 };
 
 /**


### PR DESCRIPTION
This change allows the support of basic auth headers used by `xmlrpc`.
