### PR TITLE
Add Secure Flag for xmlrpc.createSecureClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,7 @@
   "engines": {
     "node": ">=0.10.20"
   },
-  "dependencies" : {
-    "request": "2.34.0",
-    "xmlrpc": "1.2.0"
-  },
+  "dependencies" : {},
   "keywords": [
     "magento",
     "soap",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "magento",
-  "author": "Tim Marshall <timothyjmarshall@gmail.com>",
+  "author": "Stephen Keep <stephenkeep@gmail.com>",
   "description": "Magento SOAP API wrapper for Node.js",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "./src/magento",
   "contributors": [
+    {
+      "name": "Stephen Keep",
+      "email": "stephenkeep@gmail.com"
+    },
     {
       "name": "Tim Marshall",
       "email": "timothyjmarshall@gmail.com"
@@ -23,6 +27,6 @@
     "api",
     "xml"
   ],
-  "repository": "git://github.com/MadisonReed/magentoapi",
+  "repository": "git://github.com/stephenkeep/magentoapi",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
   "engines": {
     "node": ">=0.10.20"
   },
-  "dependencies" : {},
+  "dependencies" : {
+-    "request": "2.34.0",
+-    "xmlrpc": "1.2.0"
+-  },
   "keywords": [
     "magento",
     "soap",

--- a/src/magento.js
+++ b/src/magento.js
@@ -77,7 +77,13 @@ function Magento(config) {
   }
 
   this.config = magentoConfig;
-  this.client = xmlrpc.createClient(this.config);
+  
+  if (this.config.secure === true) {
+    this.client = xmlrpc.createSecureClient(this.config);
+  } else { 
+    this.client = xmlrpc.createClient(this.config);  
+  }
+  
   this.queue = [];
   this.queue.running = 0;
   this.queue.parallelLimit = this.config.parallelLimit;

--- a/src/magento.js
+++ b/src/magento.js
@@ -48,7 +48,8 @@ var configDefaults = {
   path: mandatory,
   login: mandatory,
   pass: mandatory,
-  parallelLimit: Infinity
+  parallelLimit: Infinity,
+  secure: false
 };
 
 /**


### PR DESCRIPTION
I have added a secure flag so that you can define wether to use xmlrpc.createClient or 
xmlrpc.createSecureClient. 

To implement set secure to true:

var magento = new MagentoAPI({
  host: 'your.host',
  port: 80,
  path: '/api/xmlrpc/',
  login: 'your_username',
  pass: 'your_pass'
  secure: true
});

Default is set to false.
